### PR TITLE
Add Tech Stack Filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "compression": "^1.7.1",
     "polka": "next",
-    "sirv": "^0.4.0"
+    "sirv": "^0.4.0",
+    "svelte-select": "^4.4.7"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,4 +1,5 @@
 <script>
+  import Select from 'svelte-select';
   import { onMount } from 'svelte';
   import people from "../data/people.js";
 
@@ -42,6 +43,27 @@
       sortedPeople = sortedPeople.filter(people => people.location === value)
     }
   }
+
+  let getAllTechStack = [...new Set(people.map(person => person.tech_stack.map(tech => tech.toUpperCase())).flat())].sort()
+
+  function handleStackChange(e) {
+    const values = e.detail ? e.detail.map(value => value.value) : []
+    getSortedPeople()
+
+    if (!values.length) return
+
+    sortedPeople = sortedPeople.filter(person => {
+      let isExist = false
+      values.some(value => {
+        if (person.tech_stack.map(stack => stack.toUpperCase()).includes(value)) {
+          isExist = true
+          return true
+        }
+      })
+      return isExist
+    })
+  }
+
 
   let badges = [];
   function getBadgeStyle(text) {
@@ -132,6 +154,10 @@
       <option value={location}>{location}</option>
     {/each}
   </select>
+</div>
+<div>
+  <span>Cari Berdasarkan Tech Stack</span>
+  <Select on:select={handleStackChange} items={getAllTechStack} isMulti={true}></Select>
 </div>
 <div>
   {#each sortedPeople as p}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -6,7 +6,7 @@
   let sortedPeople = []
   let getAllLocation = people.map(person => person.location)
   getAllLocation = [...new Set(getAllLocation)].sort((a, b) => a.localeCompare(b)) // get unique location and filter by alphabetically
-  let getAllTechStack = [...new Set(people.map(person => person.tech_stack.map(tech => tech.toUpperCase())).flat())].sort()
+  let getAllTechStack = [...new Set(people.filter(person => !person.hired).map(person => person.tech_stack.map(tech => tech.toUpperCase())).flat())].sort()
 
   function getSortedPeople() {
     // previous sorting doesn't work as expected

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -6,6 +6,7 @@
   let sortedPeople = []
   let getAllLocation = people.map(person => person.location)
   getAllLocation = [...new Set(getAllLocation)].sort((a, b) => a.localeCompare(b)) // get unique location and filter by alphabetically
+  let getAllTechStack = [...new Set(people.map(person => person.tech_stack.map(tech => tech.toUpperCase())).flat())].sort()
 
   function getSortedPeople() {
     // previous sorting doesn't work as expected
@@ -34,34 +35,46 @@
     });
   }
 
-  // handle filter location
-  function handleLocationChange(e) {
-    const value = e.detail ? e.detail.value : null
-    if (!value) getSortedPeople()
-    else {
-      getSortedPeople()
-      sortedPeople = sortedPeople.filter(people => people.location === value)
-    }
+  // Store filter data to implement multiple filtering
+  const filter = {
+    location: '',
+    techStacks: []
   }
 
-  let getAllTechStack = [...new Set(people.map(person => person.tech_stack.map(tech => tech.toUpperCase())).flat())].sort()
-
-  function handleStackChange(e) {
-    const values = e.detail ? e.detail.map(value => value.value) : []
+  // Filter function triggered by any filter changes
+  function filterPeople() {
     getSortedPeople()
 
-    if (!values.length) return
+    if (filter.location) {
+      sortedPeople = sortedPeople.filter(person => person.location === filter.location)
+    }
 
-    sortedPeople = sortedPeople.filter(person => {
+    if (filter.techStacks.length) {
+      sortedPeople = sortedPeople.filter(person => {
       let isExist = false
-      values.some(value => {
-        if (person.tech_stack.map(stack => stack.toUpperCase()).includes(value)) {
+      filter.techStacks.some(techStack => {
+        if (person.tech_stack.map(stack => stack.toUpperCase()).includes(techStack)) {
           isExist = true
           return true
         }
       })
       return isExist
     })
+    }
+  }
+
+  function handleLocationChange(e) {
+    const location = e.detail ? e.detail.value : null
+    filter.location = location
+
+    filterPeople()
+  }
+
+  function handleStackChange(e) {
+    const techStacks = e.detail ? e.detail.map(value => value.value) : []
+    filter.techStacks = techStacks
+
+    filterPeople()
   }
 
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -36,7 +36,7 @@
 
   // handle filter location
   function handleLocationChange(e) {
-    const value = e.target.value
+    const value = e.detail ? e.detail.value : null
     if (!value) getSortedPeople()
     else {
       getSortedPeople()
@@ -121,16 +121,13 @@
     font-weight: 870;
   }
 
-  .filter-location-wrapper {
-    display: grid;
-    justify-content: flex-end;
-    align-items: center;
-    grid-template-columns: repeat(2, max-content);
-    grid-column-gap: 8px;
+  .filter {
+    display: flex;
+    gap: 2rem;
   }
 
-  .filter-location-wrapper select {
-    padding: 3px 40px 3px 0;
+  .filter > div {
+    flex: 1 1 0%;
   }
 </style>
 
@@ -146,18 +143,15 @@
   Sekarang, kami buat jadi mudah! Berikut adalah daftar engineer keren yang
   terkena dampak pemutusan hubungan kerja karena pandemi.
 </p>
-<div class="filter-location-wrapper">
-  <span>Cari Berdasarkan Lokasi</span>
-  <select on:change={handleLocationChange}>
-    <option value="">Semua Lokasi</option>
-    {#each getAllLocation as location}
-      <option value={location}>{location}</option>
-    {/each}
-  </select>
-</div>
-<div>
-  <span>Cari Berdasarkan Tech Stack</span>
-  <Select on:select={handleStackChange} items={getAllTechStack} isMulti={true}></Select>
+<div class="filter">
+  <div>
+    <span>Cari Berdasarkan Tech Stack</span>
+    <Select on:select={handleStackChange} items={getAllTechStack} isMulti={true} />
+  </div>
+  <div>
+    <span>Cari Berdasarkan Lokasi</span>
+    <Select on:select={handleLocationChange} on:clear={handleLocationChange} items={getAllLocation} />
+  </div>
 </div>
 <div>
   {#each sortedPeople as p}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3080,6 +3080,11 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+svelte-select@^4.4.7:
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/svelte-select/-/svelte-select-4.4.7.tgz#fc85414af070487d68e438f7249c653178860af3"
+  integrity sha512-fIf9Z8rPI6F8naHZ9wjXT0Pv5gLyhdHAFkHFJnCfVVfELE8e82uOoF0xEVQP6Kir+b4Q5yOvNAzZ61WbSU6A0A==
+
 svelte@^3.0.0:
   version "3.23.0"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.23.0.tgz#bbcd6887cf588c24a975b14467455abfff9acd3f"


### PR DESCRIPTION
## Problems

The website can only filter the people/engineers only by their location. The employer might find it hard to search for specific engineers that match their requirements.

## Solution

- Add the Tech-Stack filter feature

## Implementation

 - Added [Svelte-Select library](https://github.com/rob-balfre/svelte-select) to provide a `Select` component with common features (e.g. Multi-values)
 - Added Tech-Stack filter component and function to filter people/engineers by inputted stacks
 - Repositioned filter layout (Tech-Stack and Location filter) using `flex` 
 - Refactored filter function and implemented multiple filtering that triggers a single function. It would be easy to add another filter feature in the future